### PR TITLE
use passed redis connection object rather than create one

### DIFF
--- a/openidredis/__init__.py
+++ b/openidredis/__init__.py
@@ -45,14 +45,8 @@ def _filenameEscape(s):
 
 class RedisStore(OpenIDStore):
     """Implementation of OpenIDStore for Redis"""
-    def __init__(self, conn=None, key_prefix='oid_redis'):
-        if conn:
-            self._conn = conn
-        else:
-            self._conn = redis.Redis()
-        self.host = self._conn.connection_pool.connection_kwargs['host']
-        self.port = self._conn.connection_pool.connection_kwargs['port']
-        self.db = self._conn.connection_pool.connection_kwargs['db']
+    def __init__(self, conn, key_prefix='oid_redis'):
+        self._conn = conn
         self.key_prefix = key_prefix
         self.log_debug = logging.DEBUG >= log.getEffectiveLevel()
     

--- a/openidredis/__init__.py
+++ b/openidredis/__init__.py
@@ -45,8 +45,18 @@ def _filenameEscape(s):
 
 class RedisStore(OpenIDStore):
     """Implementation of OpenIDStore for Redis"""
-    def __init__(self, conn, key_prefix='oid_redis'):
-        self._conn = conn
+    def __init__(self, host='localhost', port=6379, db=0,
+            key_prefix='oid_redis', conn=None):
+        if conn is not None:
+            self._conn = conn
+            self.host = self._conn.connection_pool.connection_kwargs['host']
+            self.port = self._conn.connection_pool.connection_kwargs['port']
+            self.db = self._conn.connection_pool.connection_kwargs['db']
+        else:
+            self.host = host
+            self.port = port
+            self.db = db
+            self._conn = redis.Redis(host=self.host, port=self.port, db=self.db)
         self.key_prefix = key_prefix
         self.log_debug = logging.DEBUG >= log.getEffectiveLevel()
     

--- a/openidredis/__init__.py
+++ b/openidredis/__init__.py
@@ -45,14 +45,18 @@ def _filenameEscape(s):
 
 class RedisStore(OpenIDStore):
     """Implementation of OpenIDStore for Redis"""
-    def __init__(self, conn=None, key_prefix='oid_redis'):
-        if conn:
+    def __init__(self, host='localhost', port=6379, db=0,
+            key_prefix='oid_redis', conn=None):
+        if conn is not None:
             self._conn = conn
+            self.host = self._conn.connection_pool.connection_kwargs['host']
+            self.port = self._conn.connection_pool.connection_kwargs['port']
+            self.db = self._conn.connection_pool.connection_kwargs['db']
         else:
-            self._conn = redis.Redis()
-        self.host = self._conn.connection_pool.connection_kwargs['host']
-        self.port = self._conn.connection_pool.connection_kwargs['port']
-        self.db = self._conn.connection_pool.connection_kwargs['db']
+            self.host = host
+            self.port = port
+            self.db = db
+            self._conn = redis.Redis(host=self.host, port=self.port, db=self.db)
         self.key_prefix = key_prefix
         self.log_debug = logging.DEBUG >= log.getEffectiveLevel()
     

--- a/openidredis/__init__.py
+++ b/openidredis/__init__.py
@@ -45,13 +45,16 @@ def _filenameEscape(s):
 
 class RedisStore(OpenIDStore):
     """Implementation of OpenIDStore for Redis"""
-    def __init__(self, host='localhost', port=6379, db=0, key_prefix='oid_redis'):
-        self.host = host
-        self.port = port
-        self.db = db
+    def __init__(self, conn=None, key_prefix='oid_redis'):
+        if conn:
+            self._conn = conn
+        else:
+            self._conn = redis.Redis()
+        self.host = self._conn.connection_pool.connection_kwargs['host']
+        self.port = self._conn.connection_pool.connection_kwargs['port']
+        self.db = self._conn.connection_pool.connection_kwargs['db']
         self.key_prefix = key_prefix
         self.log_debug = logging.DEBUG >= log.getEffectiveLevel()
-        self._conn = redis.Redis(host=self.host, port=self.port, db=self.db)
     
     def getAssociationFilename(self, server_url, handle):
         """Create a unique filename for a given server url and

--- a/tests/test_redisstore.py
+++ b/tests/test_redisstore.py
@@ -236,12 +236,22 @@ def test_redisstore():
     import redis
     from openidredis import RedisStore
 
-    r = redis.Redis()
+    conn = redis.Redis()
+
+    def clear_keys():
+        # Clear out old keys
+        for key in conn.keys('oid_redis_test*'):
+            conn.delete(key)
+
+    # Don't pass a redis connection instance, leaving it up to openid-redis to
+    # create one.
     try:
         _store_check(RedisStore(key_prefix='oid_redis_test'))
-        _store_check(RedisStore(r, key_prefix='oid_redis_test'))
     finally:
-        # Clear out old keys
-        r = redis.Redis()
-        for key in r.keys('oid_redis_test*'):
-            r.delete(key)
+        clear_keys()
+
+    # Pass optional redis connection instance.
+    try:
+        _store_check(RedisStore(key_prefix='oid_redis_test', conn=conn))
+    finally:
+        clear_keys()

--- a/tests/test_redisstore.py
+++ b/tests/test_redisstore.py
@@ -237,9 +237,21 @@ def test_redisstore():
     from openidredis import RedisStore
 
     conn = redis.Redis()
-    try:
-        _store_check(RedisStore(conn, key_prefix='oid_redis_test'))
-    finally:
+
+    def clear_keys():
         # Clear out old keys
         for key in conn.keys('oid_redis_test*'):
             conn.delete(key)
+
+    # Don't pass a redis connection instance, leaving it up to openid-redis to
+    # create one.
+    try:
+        _store_check(RedisStore(conn, key_prefix='oid_redis_test'))
+    finally:
+        clear_keys()
+
+    # Pass optional redis connection instance.
+    try:
+        _store_check(RedisStore(key_prefix='oid_redis_test', conn=conn))
+    finally:
+        clear_keys()

--- a/tests/test_redisstore.py
+++ b/tests/test_redisstore.py
@@ -233,12 +233,15 @@ def _store_check(store):
         nonceModule.SKEW = orig_skew
 
 def test_redisstore():
+    import redis
     from openidredis import RedisStore
+
+    r = redis.Redis()
     try:
         _store_check(RedisStore(key_prefix='oid_redis_test'))
+        _store_check(RedisStore(r, key_prefix='oid_redis_test'))
     finally:
         # Clear out old keys
-        import redis
         r = redis.Redis()
         for key in r.keys('oid_redis_test*'):
             r.delete(key)

--- a/tests/test_redisstore.py
+++ b/tests/test_redisstore.py
@@ -236,12 +236,10 @@ def test_redisstore():
     import redis
     from openidredis import RedisStore
 
-    r = redis.Redis()
+    conn = redis.Redis()
     try:
-        _store_check(RedisStore(key_prefix='oid_redis_test'))
-        _store_check(RedisStore(r, key_prefix='oid_redis_test'))
+        _store_check(RedisStore(conn, key_prefix='oid_redis_test'))
     finally:
         # Clear out old keys
-        r = redis.Redis()
-        for key in r.keys('oid_redis_test*'):
-            r.delete(key)
+        for key in conn.keys('oid_redis_test*'):
+            conn.delete(key)


### PR DESCRIPTION
I think it's a bit awkward and wasteful that openid-redis insists on creating a redis.Redis connection instance. Presumably, if someone is using redis for Open ID authentication, s/he is using it for other things too, so s/he is likely to already have a connection set up. I think it's neater to just require a redis client as a parameter to **init**.
