### PR TITLE
Fix egg tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [egg_info]
-tag_build = dev
+tag_build = 
 tag_svn_revision = true
 
 [nosetests]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='openid-redis',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=["redis>=2.4.0", "python-openid>=2.2.5"],
       entry_points="""
       # -*- Entry points: -*-
       """,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0'
+version = '1.0.1'
 
 setup(name='openid-redis',
       version=version,


### PR DESCRIPTION
`python setup.py sdist` adds "dev" at the end of the egg name, which we don't want. This is causing personal-chef to blow up.
