### PR TITLE
Replace calls to the Redis command KEYS with calls to SCAN

### DIFF
--- a/openidredis/__init__.py
+++ b/openidredis/__init__.py
@@ -47,7 +47,8 @@ class RedisStore(OpenIDStore):
     """Implementation of OpenIDStore for Redis"""
     def __init__(self, host='localhost', port=6379, db=0,
             key_prefix='oid_redis', conn=None, unix_socket=None,
-            password=None):
+            password=None, scan_count=None):
+        self._scan_count = scan_count
         if conn is not None:
             self._conn = conn
             try:
@@ -131,7 +132,7 @@ class RedisStore(OpenIDStore):
             cursor = 0
             assocs = set()
             while True:
-                state = self._conn.scan(cursor, '%s*' % key_name)
+                state = self._conn.scan(cursor, '%s*' % key_name, self._scan_count)
                 cursor = state[0]
                 for key in state[1]:
                     assocs.add(key)
@@ -206,7 +207,7 @@ class RedisStore(OpenIDStore):
         cursor = 0
         keys = set()
         while True:
-            state = self._conn.scan(cursor, '%s-nonce-*' % self.key_prefix)
+            state = self._conn.scan(cursor, '%s-nonce-*' % self.key_prefix, self._scan_count)
             cursor = state[0]
             for key in state[1]:
                 keys.add(key)

--- a/tests/test_redisstore.py
+++ b/tests/test_redisstore.py
@@ -255,3 +255,9 @@ def test_redisstore():
         _store_check(RedisStore(key_prefix='oid_redis_test', conn=conn))
     finally:
         clear_keys()
+
+    # Pass optional redis connection instance and optional scan_count
+    try:
+        _store_check(RedisStore(key_prefix='oid_redis_test', conn=conn, scan_count=1000))
+    finally:
+        clear_keys()


### PR DESCRIPTION
Notes: 
- SCAN was added in Redis 2.8; if this change is merged, openid-redis will only work with Redis 2.8 or later.
- The results from the calls to SCAN are stored in a set() instead of a list because SCAN might return the same key in multiple calls
